### PR TITLE
solve error upath@1.0.4: The engine "node" is incompatible with this …

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ build-vue:
 
 .PHONY: install-vue
 install-vue:
-	cd web/vue && yarn install
+	cd web/vue && yarn config set ignore-engines && yarn install
 
 .PHONY: run-vue
 run-vue:


### PR DESCRIPTION
yarn install
yarn install v1.22.10
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning webpack > watchpack > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
[3/5] 🚚  Fetching packages...
error upath@1.0.4: The engine "node" is incompatible with this module. Expected version ">=4 <=9". Got "16.2.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.