### PR TITLE
limit shell task output length in server.go

### DIFF
--- a/internal/modules/rpc/server/server.go
+++ b/internal/modules/rpc/server/server.go
@@ -40,6 +40,9 @@ func (s Server) Run(ctx context.Context, req *pb.TaskRequest) (*pb.TaskResponse,
 	output, err := utils.ExecShell(ctx, req.Command)
 	resp := new(pb.TaskResponse)
 	resp.Output = output
+	if outputLen := len(output); outputLen > 5000 {
+		resp.Output = output[outputLen-5000:]
+	}
 	if err != nil {
 		resp.Error = err.Error()
 	} else {


### PR DESCRIPTION
if task output length is too long, it will cause the result write failure and the task status cannot be set to 0.